### PR TITLE
Disable digest updates in renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>platform-engineering-org/.github",
-    ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    ":disableDigestUpdates"
   ]
 }


### PR DESCRIPTION
## Changes introduced with this PR

We decided that hash pinning was not adding any value for us. Just noise and stale hashes.

Here is the documentation for this:
https://docs.renovatebot.com/presets-default/#disabledigestupdates

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).