### PR TITLE
Disable pinning, and re-enable digest updates.

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -3,6 +3,6 @@
   "extends": [
     "github>platform-engineering-org/.github",
     ":disableDependencyDashboard",
-    ":disableDigestUpdates"
+    ":pinDigestsDisabled"
   ]
 }


### PR DESCRIPTION
## Changes introduced with this PR

We have decided that the best course of action would be to disable pinning, but leave digest updates on to prompt us to remove the pinned versions.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).