### PR TITLE
Override the Renovate bot pin-digests presets from `config:best-practices`

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -4,5 +4,21 @@
     "github>platform-engineering-org/.github",
     ":disableDependencyDashboard",
     ":pinDigestsDisabled"
+  ],
+  "packageRules": [
+    {
+      "description": "Override the docker:pinDigests preset provided by config:best-practices",
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": false
+    },
+    {
+      "description": "Override the helpers:pinGitHubActionDigests preset provided by config:best-practices",
+      "matchDepTypes": [
+        "action"
+      ],
+      "pinDigests": false
+    }
   ]
 }


### PR DESCRIPTION
## Changes introduced with this PR

The Renovate configuration for the Arcalot repositories includes the configuration from [platform-engineering-org/.github/default.json](https://github.com/platform-engineering-org/.github/blob/main/default.json) which in turn incorporates a number of Renovate presets, including `config:best-practices`.  This preset includes the presets, `docker:pinDigests` and `helpers:pinGitHubActionDigests`, which have the effect of pinning Docker images and GitHub Action images (respectively) using hash digest values.  And, unfortunately, there doesn't seem to be any nice way to override these presets once they are included, and they seem to take precedence over a subsequently specified `:pinDigestsDisabled`.

This PR adds to the shared configuration for the Arcalot repositories the raw configurations analogous to `docker:pinDigests` and `helpers:pinGitHubActionDigests` with the opposite configuration value, which does turn off digest-pinning for these two types of references.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).