### PR TITLE
Update Renovate configuration for new bot implementation

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>platform-engineering-org/.github",
+    "github>redhat-exd-rebuilds/renovate-config",
     ":disableDependencyDashboard",
     ":pinDigestsDisabled"
   ]


### PR DESCRIPTION
## Changes introduced with this PR

The Red Hat version of the Renovate bot was recently updated to a new implementation.  Our configuration for the bot extends an upstream configuration which was tailored to the old bot.  The definition of `gitAuthor` in that configuration seems to produce an identity crisis in the new bot.

We are [advised](https://redhat-internal.slack.com/archives/C05C958BQLS/p1715763272066169?thread_ts=1715706341.392469&cid=C05C958BQLS) to update our configuration to  point to a [new upstream configuration](https://github.com/redhat-exd-rebuilds/renovate-config/tree/main) tailored to the new bot.

This PR makes that change.

I don't really know how to test this other than by trying it out....

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).