### PR TITLE
Schedule Renovate updates for Arca dependences 'at any time'

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -7,7 +7,7 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["github.com/arcalot/*"],
+      "matchPackageNames": ["github.com/arcalot/*", "*.arcalot.io/**"],
       "schedule": ["at any time"],
       "lockFileMaintenance": {
         "enabled": true,


### PR DESCRIPTION
## Changes introduced with this PR

The [common Red Hat Renovate configuration](https://github.com/redhat-exd-rebuilds/renovate-config/blob/main/default.json) limits the bot to creating PRs on a weekly basis.  For managing dependencies between the Arca repositories, this is inconveniently infrequent.  This PR attempts to override that setting, just for the Arca repos, to allow the bot to create PRs for updates to these dependencies whenever it runs (e.g., hourly).  (There is a separate configuration for "lock files", so this change encompasses those as well as other dependency declarations.)

_[Unfortunately, since this file is used only indirectly, I don't know how to test this change other than by merging it.]_

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).