### PR TITLE
Disable Renovate updates to the Go toolchain version

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -9,6 +9,11 @@
     {
       "matchPackageNames": ["github.com/arcalot/*", "*.arcalot.io/**"],
       "schedule": null
+    },
+    {
+      "matchCategories": ["golang"],
+      "matchDepTypes": ["toolchain"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Changes introduced with this PR

This change endeavors to prevent the Renovate bot from proposing updates to the Go `toolchain` directive.  We will perform these updates manually at a time of our choosing.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).