### PR TITLE
Try to avoid updates to minimum versions for Python dependencies

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -14,6 +14,10 @@
       "matchCategories": ["golang"],
       "matchDepTypes": ["toolchain"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["poetry"],
+      "rangeStrategy": "update-lockfile"
     }
   ]
 }


### PR DESCRIPTION
## Changes introduced with this PR

Since we pin our (Python) dependencies using Poetry (via the `poetry.lock` file, which Renovate already maintains for us, I think), there is no reason to _also_ update our **minimum** dependencies (in `pyproject.toml`) -- this just produces unnecessary noise and churn.

This PR tweaks the Renovate configuration, to hopefully get the bot to leave the TOML file alone when there is an update to a Python dependency (unless the update is actually necessary).  ([Doc ref](https://docs.renovatebot.com/configuration-options/#rangestrategy))

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).